### PR TITLE
eli-216 adding APIM target headers to allow us to receive NHS Login NHS number

### DIFF
--- a/specification/eligibility-signposting-api.yaml
+++ b/specification/eligibility-signposting-api.yaml
@@ -774,3 +774,6 @@ x-nhsd-apim:
         $ref: "x-nhsd-apim/target.yaml"
     ratelimiting:
         $ref: "x-nhsd-apim/ratelimit.yaml"
+    target-identity:
+      - name: nhs-login-nhs-number
+        header: "nhs-login-nhs-number"


### PR DESCRIPTION

<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Adding target headers to trigger the APIM proxy to include the NHS Login NHS Number in the request to us.

## Context

We want to a) log, for audit purposes, the identity of requestors and b) potentially cross-check the NHS number in the path vs. the NHS Login user NHS Number for authorisation purposes.
## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [x] I have added tests to cover my changes
- [x] I have updated the documentation accordingly
- [x] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
